### PR TITLE
Princípio de liskov aplicado

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # vote
 Voting application to exemplify the use of spring boot in building an API
+
+# Correções
+
+## O **contrato da interface** (`AssociateService`) usa ​**String como identificador**​, mas a implementação pensa que o ID é **Long** (`Long.parseLong(id)`).
+
+Se criarmos outra implementação que use UUID ou outro tipo de identificador, ela **não poderá substituir** a implementação atual sem quebrar o comportamento esperado.
+
+Isso ​**viola o Princípio de Liskov**​, pois:
+
+* O subtipo (`AssociateServiceImpl`) altera a semântica do contrato definido pela interface.
+* Um consumidor do serviço não pode usar outra implementação sem quebrar a compatibilidade.
+
+## Marcelo Henrique Rosendo da Silva

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ Voting application to exemplify the use of spring boot in building an API
 
 # Correções
 
-## O **contrato da interface** (`AssociateService`) usa ​**String como identificador**​, mas a implementação pensa que o ID é **Long** (`Long.parseLong(id)`).
+## O **contrato da interface** (AssociateService) usa ​**String como identificador**​, mas a implementação pensa que o ID é **Long** (Long.parseLong(id)).
 
 Se criarmos outra implementação que use UUID ou outro tipo de identificador, ela **não poderá substituir** a implementação atual sem quebrar o comportamento esperado.
 
 Isso ​**viola o Princípio de Liskov**​, pois:
 
-* O subtipo (`AssociateServiceImpl`) altera a semântica do contrato definido pela interface.
+* O subtipo (AssociateServiceImpl) altera a semântica do contrato definido pela interface.
 * Um consumidor do serviço não pode usar outra implementação sem quebrar a compatibilidade.
 
 ## Marcelo Henrique Rosendo da Silva

--- a/src/main/java/br/com/voting/vote/controllers/AssociateController.java
+++ b/src/main/java/br/com/voting/vote/controllers/AssociateController.java
@@ -29,18 +29,18 @@ public class AssociateController {
     }
 
     @GetMapping(path = "{id}")
-    public ResponseEntity<Associate> getById(@PathVariable("id") String id) {
+    public ResponseEntity<Associate> getById(@PathVariable("id") Long id) {
         return ResponseEntity.ok(associateService.findById(id));
     }
 
     @DeleteMapping(path = "{id}")
-    public ResponseEntity<Void> removeAssociate(@PathVariable("id") String id) {
+    public ResponseEntity<Void> removeAssociate(@PathVariable("id") Long id) {
         associateService.deleteAssociate(id);
         return ResponseEntity.noContent().build();
     }
 
     @PutMapping(path = "{id}")
-    public ResponseEntity<Void> updateAssociate(@PathVariable("id") String id,
+    public ResponseEntity<Void> updateAssociate(@PathVariable("id") Long id,
                                                 @RequestBody AssociateDTO associateDTO) {
         associateService.updateAssociate(associateDTO, id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/br/com/voting/vote/services/AssociateService.java
+++ b/src/main/java/br/com/voting/vote/services/AssociateService.java
@@ -10,9 +10,9 @@ public interface AssociateService {
 
     List<Associate> findAll();
 
-    Associate findById(String id);
+    Associate findById(Long id);
 
-    void deleteAssociate(String id);
+    void deleteAssociate(Long id);
 
-    void updateAssociate(AssociateDTO associateDTO, String id);
+    void updateAssociate(AssociateDTO associateDTO, Long id);
 }

--- a/src/main/java/br/com/voting/vote/services/impl/AssociateServiceImpl.java
+++ b/src/main/java/br/com/voting/vote/services/impl/AssociateServiceImpl.java
@@ -35,13 +35,14 @@ public class AssociateServiceImpl implements AssociateService {
     }
 
     @Override
-    public Associate findById(String id) {
-        return repository.findById(Long.parseLong(id)).orElseThrow(() ->
+    public Associate findById(Long id) {
+        // Mudança para Long ao ivés de usar o parseLong
+        return repository.findById(id).orElseThrow(() ->
                 new NotFoundException("Associado não encontrado"));
     }
 
     @Override
-    public void deleteAssociate(String id) {
+    public void deleteAssociate(Long id) {
         Associate associate = findById(id);
 
         if (associate != null) {
@@ -51,7 +52,7 @@ public class AssociateServiceImpl implements AssociateService {
 
     @Transactional
     @Override
-    public void updateAssociate(AssociateDTO associateDTO, String id) {
+    public void updateAssociate(AssociateDTO associateDTO, Long id) {
         Associate associate = findById(id);
         if (associate != null) {
             associate.setCpf(associateDTO.getCpf());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,6 @@ spring.datasource.password=admin
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+
+
+server.port=8081


### PR DESCRIPTION
Correções

O contrato da interface (AssociateService) usa ​String como identificador​, mas a implementação pensa que o ID é Long (Long.parseLong(id)).

Se criarmos outra implementação que use UUID ou outro tipo de identificador, ela **não poderá substituir** a implementação atual sem quebrar o comportamento esperado.

Isso ​viola o Princípio de Liskov​, pq:

* O subtipo (`AssociateServiceImpl`) altera a semântica do contrato definido pela interface.
* Um consumidor do serviço não pode usar outra implementação sem quebrar a compatibilidade.