### PR TITLE
Aplicação do Princípio de Substituição de Liskov no AssociateController

### DIFF
--- a/src/main/java/br/com/voting/vote/controllers/AssociateController.java
+++ b/src/main/java/br/com/voting/vote/controllers/AssociateController.java
@@ -2,7 +2,7 @@ package br.com.voting.vote.controllers;
 
 import br.com.voting.vote.dtos.AssociateDTO;
 import br.com.voting.vote.models.Associate;
-import br.com.voting.vote.services.AssociateService;
+import br.com.voting.vote.services.IAssociateService; // <- agora depende da interface
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +15,7 @@ import java.util.List;
 public class AssociateController {
 
     @Autowired
-    private AssociateService associateService;
+    private IAssociateService associateService; // <- usa a abstração, não a implementação
 
     @GetMapping
     public ResponseEntity<List<Associate>> getAll() {
@@ -45,6 +45,4 @@ public class AssociateController {
         associateService.updateAssociate(associateDTO, id);
         return ResponseEntity.noContent().build();
     }
-
-
 }


### PR DESCRIPTION
Este PR aplica o Princípio de Substituição de Liskov (LSP) ao AssociateController.

Criada a interface IAssociateService para definir o contrato do serviço.

Alterado o AssociateController para depender da interface em vez da implementação concreta AssociateService.

A mudança garante desacoplamento, flexibilidade na troca de implementações e maior testabilidade do código.