### PR TITLE
Liskov aplicado com herança

### DIFF
--- a/src/main/java/br/com/voting/vote/controllers/AssociateController.java
+++ b/src/main/java/br/com/voting/vote/controllers/AssociateController.java
@@ -1,14 +1,23 @@
 package br.com.voting.vote.controllers;
 
-import br.com.voting.vote.dtos.AssociateDTO;
-import br.com.voting.vote.models.Associate;
-import br.com.voting.vote.services.AssociateService;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import br.com.voting.vote.dtos.AssociateDTO;
+import br.com.voting.vote.models.Associate;
+import br.com.voting.vote.services.AssociateService;
+import br.com.voting.vote.services.PremiumAssociateService;
 
 @RestController
 @RequestMapping("/associate")
@@ -45,6 +54,16 @@ public class AssociateController {
         associateService.updateAssociate(associateDTO, id);
         return ResponseEntity.noContent().build();
     }
+    
+    @PostMapping(path = "{id}/grant-benefits")
+public ResponseEntity<String> grantPremiumBenefits(@PathVariable("id") String id) {
+    if (associateService instanceof PremiumAssociateService premiumService) {
+        premiumService.grantPremiumBenefits(id);
+        return ResponseEntity.ok("Benefícios premium concedidos ao associado com ID " + id);
+    }
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body("Esta implementação de serviço não suporta benefícios premium.");
+}
 
 
 }

--- a/src/main/java/br/com/voting/vote/dtos/AssociateDTO.java
+++ b/src/main/java/br/com/voting/vote/dtos/AssociateDTO.java
@@ -18,7 +18,7 @@ public class AssociateDTO {
         return name;
     }
 
-    public void setNome(String name) {
+    public void setName(String name) {
         this.name = name;
     }
 

--- a/src/main/java/br/com/voting/vote/services/PremiumAssociateService.java
+++ b/src/main/java/br/com/voting/vote/services/PremiumAssociateService.java
@@ -1,0 +1,5 @@
+package br.com.voting.vote.services;
+
+public interface PremiumAssociateService extends AssociateService {
+    void grantPremiumBenefits(String id);
+}

--- a/src/main/java/br/com/voting/vote/services/impl/PremiumAssociateServiceImpl.java
+++ b/src/main/java/br/com/voting/vote/services/impl/PremiumAssociateServiceImpl.java
@@ -1,21 +1,22 @@
 package br.com.voting.vote.services.impl;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
 import br.com.voting.vote.dtos.AssociateDTO;
 import br.com.voting.vote.exception.NotFoundException;
 import br.com.voting.vote.models.Associate;
 import br.com.voting.vote.repositories.AssociateRepository;
-import br.com.voting.vote.services.AssociateService;
+import br.com.voting.vote.services.PremiumAssociateService;
 import jakarta.transaction.Transactional;
-import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
-public class AssociateServiceImpl implements AssociateService {
+public class PremiumAssociateServiceImpl implements PremiumAssociateService {
 
     private final AssociateRepository repository;
 
-    public AssociateServiceImpl(AssociateRepository repository) {
+    public PremiumAssociateServiceImpl(AssociateRepository repository) {
         this.repository = repository;
     }
 
@@ -25,6 +26,8 @@ public class AssociateServiceImpl implements AssociateService {
         Associate associate = new Associate();
         associate.setName(associateDTO.getName());
         associate.setCpf(associateDTO.getCpf());
+
+        // Pode ter lógica adicional para associados premium aqui
 
         repository.save(associate);
     }
@@ -58,5 +61,12 @@ public class AssociateServiceImpl implements AssociateService {
             associate.setName(associateDTO.getName());
             repository.save(associate);
         }
+    }
+
+    @Override
+    public void grantPremiumBenefits(String id) {
+        Associate associate = findById(id);
+        // Aqui você pode implementar a lógica para conceder benefícios premium
+        System.out.println("Benefícios premium concedidos ao associado: " + associate.getName());
     }
 }

--- a/src/main/java/br/com/voting/vote/services/impl/RegularAssociateServiceImpl.java
+++ b/src/main/java/br/com/voting/vote/services/impl/RegularAssociateServiceImpl.java
@@ -1,0 +1,65 @@
+package br.com.voting.vote.services.impl;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import br.com.voting.vote.dtos.AssociateDTO;
+import br.com.voting.vote.exception.NotFoundException;
+import br.com.voting.vote.models.Associate;
+import br.com.voting.vote.repositories.AssociateRepository;
+import br.com.voting.vote.services.AssociateService;
+import jakarta.transaction.Transactional;
+
+@Service
+@Primary
+public class RegularAssociateServiceImpl implements AssociateService {
+
+    private final AssociateRepository repository;
+
+    public RegularAssociateServiceImpl(AssociateRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional
+    @Override
+    public void createAssociate(AssociateDTO associateDTO) {
+        Associate associate = new Associate();
+        associate.setName(associateDTO.getName());
+        associate.setCpf(associateDTO.getCpf());
+
+        repository.save(associate);
+    }
+
+    @Override
+    public List<Associate> findAll() {
+        return repository.findAll();
+    }
+
+    @Override
+    public Associate findById(String id) {
+        return repository.findById(Long.parseLong(id)).orElseThrow(() ->
+                new NotFoundException("Associado não encontrado"));
+    }
+
+    @Override
+    public void deleteAssociate(String id) {
+        Associate associate = findById(id);
+
+        if (associate != null) {
+            repository.delete(associate);
+        }
+    }
+
+    @Transactional
+    @Override
+    public void updateAssociate(AssociateDTO associateDTO, String id) {
+        Associate associate = findById(id);
+        if (associate != null) {
+            associate.setCpf(associateDTO.getCpf());
+            associate.setName(associateDTO.getName());
+            repository.save(associate);
+        }
+    }
+}


### PR DESCRIPTION


# **Justificativa da implementação do Princípio de Liskov (LSP)**


### Contexto:
 Para aplicar o Princípio de Liskov no projeto, adaptei o sistema para lidar com diferentes tipos de associados (regular e premium) usando uma interface comum. Assim, cada tipo tem seu comportamento específico, sem precisar mexer no código que utiliza esses serviços.

### O que fiz:
Interface AssociateService:
- Mantive como base para todas as operações CRUD.
- Não precisei mudar nada porque já estava adequada.


### Novas classes de serviço:
- Criei RegularAssociateServiceImpl, que implementa o comportamento padrão do associado.


- Criei PremiumAssociateServiceImpl, que além do básico, adiciona um método para liberar benefícios premium.


### Controller (AssociateController):
- Alterei para usar a interface no lugar da implementação direta, deixando o código mais flexível.


- Adicionei um endpoint novo /associate/{id}/grant-benefits que verifica se o serviço suporta o benefício premium antes de executar.


### Configuração do Spring:
- Usei @Primary para definir qual serviço o Spring deve injetar quando há múltiplas implementações da mesma interface.
Isso me permitiu testar ou usar cada tipo de serviço (regular ou premium) trocando apenas o @Primary entre as classes.


- É possível melhorar usando @Qualifier para escolher explicitamente a implementação ou @Profile para alternar automaticamente conforme o ambiente.


### DTO AssociateDTO:
Corrigi o método setter que estava errado (setNome virou setName) para garantir que os dados sejam mapeados corretamente e evitar erros no JSON.



### Por que isso respeita o Liskov?
- Pode trocar de serviço sem medo: tanto o RegularAssociateServiceImpl quanto o PremiumAssociateServiceImpl podem ser usados no lugar um do outro sem quebrar nada.


- O controller nem liga pra implementação: ele só chama os métodos da interface AssociateService e não precisa saber quem está por trás.


- Funcionalidades novas sem bagunça: benefícios premium foram adicionados apenas na classe específica, sem atrapalhar o comportamento normal dos associados regulares.


- Flexível e fácil de manter: consigo trocar qual serviço o Spring injeta (@Primary ou @Qualifier) sem precisar mexer no controller ou em outras partes do código.


