### PR TITLE
Liskov Aplicado

### DIFF
--- a/src/main/java/br/com/voting/vote/controllers/AssociateController.java
+++ b/src/main/java/br/com/voting/vote/controllers/AssociateController.java
@@ -29,22 +29,20 @@ public class AssociateController {
     }
 
     @GetMapping(path = "{id}")
-    public ResponseEntity<Associate> getById(@PathVariable("id") String id) {
+    public ResponseEntity<Associate> getById(@PathVariable("id") Long id) {
         return ResponseEntity.ok(associateService.findById(id));
     }
 
     @DeleteMapping(path = "{id}")
-    public ResponseEntity<Void> removeAssociate(@PathVariable("id") String id) {
+    public ResponseEntity<Void> removeAssociate(@PathVariable("id") Long id) {
         associateService.deleteAssociate(id);
         return ResponseEntity.noContent().build();
     }
 
     @PutMapping(path = "{id}")
-    public ResponseEntity<Void> updateAssociate(@PathVariable("id") String id,
+    public ResponseEntity<Void> updateAssociate(@PathVariable("id") Long id,
                                                 @RequestBody AssociateDTO associateDTO) {
-        associateService.updateAssociate(associateDTO, id);
+        associateService.updateAssociate(id, associateDTO);
         return ResponseEntity.noContent().build();
     }
-
-
 }

--- a/src/main/java/br/com/voting/vote/dtos/AssociateDTO.java
+++ b/src/main/java/br/com/voting/vote/dtos/AssociateDTO.java
@@ -2,15 +2,15 @@ package br.com.voting.vote.dtos;
 
 public class AssociateDTO {
 
-    private String id;
+    private Long id;   // agora é Long para bater com a entidade
     private String name;
     private String cpf;
 
-    public String getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(String id) {
+    public void setId(Long id) {
         this.id = id;
     }
 
@@ -18,7 +18,7 @@ public class AssociateDTO {
         return name;
     }
 
-    public void setNome(String name) {
+    public void setName(String name) {  
         this.name = name;
     }
 

--- a/src/main/java/br/com/voting/vote/services/AssociateService.java
+++ b/src/main/java/br/com/voting/vote/services/AssociateService.java
@@ -5,14 +5,23 @@ import br.com.voting.vote.models.Associate;
 
 import java.util.List;
 
+/**
+ * Contrato para operações de gerenciamento de associados.
+ * 
+ * Regras (para manter substituibilidade / princípio de Liskov):
+ * - Todos os métodos que recebem ID usam Long (consistente com o modelo e repositório).
+ * - Métodos que não encontrarem o recurso devem lançar NotFoundException (nunca retornar null).
+ * - delete é idempotente: não falha se o recurso já não existir.
+ */
 public interface AssociateService {
+
     void createAssociate(AssociateDTO associateDTO);
 
     List<Associate> findAll();
 
-    Associate findById(String id);
+    Associate findById(Long id);
 
-    void deleteAssociate(String id);
+    void deleteAssociate(Long id);
 
-    void updateAssociate(AssociateDTO associateDTO, String id);
+    void updateAssociate(Long id, AssociateDTO associateDTO);
 }

--- a/src/main/java/br/com/voting/vote/services/impl/AssociateServiceImpl.java
+++ b/src/main/java/br/com/voting/vote/services/impl/AssociateServiceImpl.java
@@ -25,7 +25,6 @@ public class AssociateServiceImpl implements AssociateService {
         Associate associate = new Associate();
         associate.setName(associateDTO.getName());
         associate.setCpf(associateDTO.getCpf());
-
         repository.save(associate);
     }
 
@@ -35,28 +34,22 @@ public class AssociateServiceImpl implements AssociateService {
     }
 
     @Override
-    public Associate findById(String id) {
-        return repository.findById(Long.parseLong(id)).orElseThrow(() ->
-                new NotFoundException("Associado não encontrado"));
+    public Associate findById(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Associado não encontrado"));
     }
 
     @Override
-    public void deleteAssociate(String id) {
-        Associate associate = findById(id);
-
-        if (associate != null) {
-            repository.delete(associate);
-        }
+    public void deleteAssociate(Long id) {
+        repository.findById(id).ifPresent(repository::delete);
     }
 
     @Transactional
     @Override
-    public void updateAssociate(AssociateDTO associateDTO, String id) {
+    public void updateAssociate(Long id, AssociateDTO associateDTO) {
         Associate associate = findById(id);
-        if (associate != null) {
-            associate.setCpf(associateDTO.getCpf());
-            associate.setName(associateDTO.getName());
-            repository.save(associate);
-        }
+        associate.setCpf(associateDTO.getCpf());
+        associate.setName(associateDTO.getName());
+        repository.save(associate);
     }
 }


### PR DESCRIPTION
Relatório – Aplicação do Princípio de Liskov (LSP) no projeto
1. Problema inicial encontrado
•	O contrato do serviço (AssociateService) definia os métodos findById(String id), deleteAssociate(String id) e updateAssociate(String id, ...).
•	A implementação (AssociateServiceImpl) assumia que esse String sempre seria um número e fazia Long.parseLong(id).
•	Isso cria uma pré-condição escondida: o contrato parece aceitar qualquer String, mas na prática só funciona com números.
•	Esse tipo de detalhe viola o Princípio de Liskov porque:
o	Uma implementação não pode “apertar” o contrato de forma a deixar de ser substituível.
o	O cliente que usa a interface não pode ser surpreendido com restrições ocultas.
2. O que foi feito para corrigir
2.1 Interface AssociateService
•	Mudança do tipo do id de String para Long.
•	Adicionada documentação no contrato especificando regras:
o	findById(Long id) lança NotFoundException se não existir.
o	deleteAssociate(Long id) é idempotente (não dá erro se o recurso já não existir).
•	Objetivo: deixar claro no contrato o que toda implementação deve fazer → qualquer implementação é substituível.
2.2 Implementação AssociateServiceImpl
•	Removido Long.parseLong(id).
•	Métodos agora recebem Long id diretamente.
•	Simplificado o deleteAssociate: agora usa repository.findById(id).ifPresent(...).
•	Objetivo: respeitar o contrato sem criar regras escondidas.
2.3 Controller AssociateController
•	Alterado o tipo do parâmetro do @PathVariable("id") de String para Long.
•	Agora o próprio Spring faz a conversão automática da URL para Long.
•	Objetivo: alinhar a API REST ao contrato correto e evitar conversões manuais.
2.4 DTO AssociateDTO
•	Corrigido método setNome → setName (seguindo JavaBean padrão).
•	Alterado o tipo do campo id de String para Long, igual à entidade Associate.
•	Objetivo: manter consistência entre DTO e entidade, além de evitar problemas de serialização/deserialização com Jackson.
2.5 Entidade Associate
•	Não precisou de alteração: já usava Long id.
3. O que foi adicionado
3.1 Teste de contrato AssociateServiceContractTest
•	Criado um teste abstrato que define como qualquer implementação de AssociateService deve se comportar:
o	findById em ID inexistente deve lançar NotFoundException.
o	Fluxo de create → update → delete deve funcionar corretamente.
•	Objetivo: garantir substituibilidade (base do Liskov).
3.2 Teste concreto AssociateServiceImplTest
•	Implementa o teste abstrato usando a classe real AssociateServiceImpl.
•	Usa @SpringBootTest e @Transactional para rodar com o banco de dados configurado.
•	Objetivo: verificar que a implementação real segue o contrato.
4. Resultado final
•	Todas as camadas (Controller, Service, ServiceImpl, DTO, Entity) estão consistentes: usam Long como identificador.
•	O contrato do serviço está explícito e sem pré-condições ocultas.
•	Criamos testes que garantem que qualquer implementação de AssociateService deve se comportar da mesma forma.
•	Agora o código respeita o Princípio de Liskov, pois qualquer implementação pode substituir outra sem quebrar os clientes que dependem da interfac
